### PR TITLE
Assume times are intended to be Drupal time

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
@@ -11,10 +11,22 @@ class DatetimeHandler extends AbstractHandler {
    * {@inheritdoc}
    */
   public function expand($values) {
+    // A Drupal install has a default user-facing timezone, but nonetheless
+    // uses UTC for internal storage. If no timezone is specified in a date
+    // field value by the step author, assume it is in the default timezone of
+    // the Drupal install, and therefore transform it into UTC for storage.
+    $dtz = \Drupal::config('system.date')->get('timezone.default');
+    // Drupal timezone is not always set, see
+    // https://api.drupal.org/api/drupal/core!includes!bootstrap.inc/function/drupal_get_user_timezone/8.2.x
+    // Ignore PHP strict notice if timezone has not yet been set in the php.ini.
+    $dtz = !empty($dtz) ? $dtz : @date_default_timezone_get();
+    $dtz = new DateTimeZone($dtz);
+    $utc = new DateTimeZone('UTC');
     foreach ($values as $key => $value) {
-      $values[$key] = str_replace(' ', 'T', $value);
+      $date = new DateTime($value, $dtz);
+      $date->setTimezone($utc);
+      $values[$key] = $date->format('Y-m-d\TH:i:s');
     }
-    return $values;
-  }
+    return $values;  }
 
 }


### PR DESCRIPTION
Drupal uses UTC for internal storage but the user's timezone (often based on the Drupal installation's configured default timezone) for storage. At the moment, values specified in steps for date fields on entities are passed straight to Drupal for saving and therefore treated by Drupal as being intended to be UTC times. 

Therefore the following scenario fails if the user timezone is not UTC:
`
Given a page:
  | title  | field_my_datetime     |
  | Test  | 2005-10-23 15:00:00 |
Then I should see "2005-10-23 15:00:00"
`

Forcing step authors to 'Given' their times in UTC but 'Then' them in some other timezone requires a lot of mental juggling and makes the logic of scenarios puzzling to the uninitiated.

I suggest the solution is to assume the given times are in the Drupal installation's default timezone, unless a timezone is explicitly specified.  This way, as long as the timezone of the test user matches that (which is easily controllable by the step author) then everything works nicely.

This may break backwards compatibility for anyone who's already got scenarios with time maths going on in them.